### PR TITLE
Update maxcpucount to allow msbuild to decide how many workers to use

### DIFF
--- a/tasks/msbuild.js
+++ b/tasks/msbuild.js
@@ -128,7 +128,12 @@ module.exports = function(grunt) {
             // maxcpucount is not supported by xbuild
             if (process.platform === 'win32') {
                 grunt.verbose.writeln('Using maxcpucount:', +options.maxCpuCount);
-                args.push('/maxcpucount:' + options.maxCpuCount);
+                if(options.maxCpuCount === true) {
+                    args.push('/maxcpucount');
+                }
+                else {
+                    args.push('/maxcpucount:' + options.maxCpuCount);
+                }
             }
         }
 


### PR DESCRIPTION
According to the MSDN:

  "If you include the /maxcpucount switch without specifying a value, MSBuild will use up to the number of processors on the computer."

This change allows you to specify the maxCpuCount as equal to 'true' instead of a hard-coded numeric value allowing the build to be more 'elastic' depending on where it is being run (developer machines vs. a build cloud for example.)
